### PR TITLE
Make sure none of teammate outlines is displayed

### DIFF
--- a/mods/Remove Teammates Outline/hook.contourext.lua
+++ b/mods/Remove Teammates Outline/hook.contourext.lua
@@ -1,8 +1,7 @@
 local Remove_add = ContourExt.add
-local ROL_setup = "teammate" or "teammate_downed" or "teammate_dead" or "teammate_cuffed" or "teammate_downed_selected"
 
 function ContourExt:add(type, ...)
-  if type ~= "ROL_setup" then
+  if type ~= "teammate" and type ~= "teammate_downed" and type ~= "teammate_dead" and type ~= "teammate_cuffed" and type ~= "teammate_downed_selected" then
     return Remove_add(self, type, ...)
   end
 end

--- a/mods/Remove Teammates Outline/hook.contourext.lua
+++ b/mods/Remove Teammates Outline/hook.contourext.lua
@@ -1,7 +1,8 @@
 local Remove_add = ContourExt.add
+local ROL_setup = "teammate" or "teammate_downed" or "teammate_dead" or "teammate_cuffed" or "teammate_downed_selected"
 
 function ContourExt:add(type, ...)
-  if type ~= "teammate" then
+  if type ~= "ROL_setup" then
     return Remove_add(self, type, ...)
   end
 end


### PR DESCRIPTION
outlines appear after bots getting downed or other case
using a local value to disable all teammate outlines