### PR TITLE
Ver. 7 - Fixes

### DIFF
--- a/mods/REBuyAssets/lua/autobuyallassets.lua
+++ b/mods/REBuyAssets/lua/autobuyallassets.lua
@@ -1,0 +1,15 @@
+_G.REBuyAssets = _G.REBuyAssets or {}
+
+Hooks:PostHook(MissionBriefingGui, "create_asset_tab", "REBuyAssets_DoAssets", function(...)
+	REBuyAssets.settings = REBuyAssets.settings or {}
+	REBuyAssets.settings["AutoBuyAllAssets"] = REBuyAssets.settings["AutoBuyAllAssets"] or 0
+	if REBuyAssets.settings["AutoBuyAllAssets"] == 1 then
+		local asset_ids = managers.assets:get_all_asset_ids(true) or {}
+		for _, asset_id in pairs(asset_ids) do
+			local asset = managers.assets:_get_asset_by_id(asset_id)
+			if asset.can_unlock then
+				managers.assets:unlock_asset(asset_id)
+			end
+		end
+	end
+end )

--- a/mods/REBuyAssets/lua/missionbriefinggui.lua
+++ b/mods/REBuyAssets/lua/missionbriefinggui.lua
@@ -1,5 +1,9 @@
 _G.REBuyAssets = _G.REBuyAssets or {}
 
+if not REBuyAssets or Network:is_client() then
+	return
+end
+
 Hooks:PostHook(AssetsItem, "chk_preplanning_textures_done", "REBuyAssets_DoPreplanning", function(...)
 	REBuyAssets:Load()
 	local current_stage = managers.job:current_level_id()
@@ -15,20 +19,6 @@ Hooks:PostHook(AssetsItem, "chk_preplanning_textures_done", "REBuyAssets_DoPrepl
 				else
 					managers.preplanning:server_unreserve_mission_element(_data.id, 1)
 				end
-			end
-		end
-	end
-end )
-
-Hooks:PostHook(MissionBriefingGui, "create_asset_tab", "REBuyAssets_DoAssets", function(...)
-	REBuyAssets.settings = REBuyAssets.settings or {}
-	REBuyAssets.settings["AutoBuyAllAssets"] = REBuyAssets.settings["AutoBuyAllAssets"] or 0
-	if REBuyAssets.settings["AutoBuyAllAssets"] == 1 then
-		local asset_ids = managers.assets:get_all_asset_ids(true) or {}
-		for _, asset_id in pairs(asset_ids) do
-			local asset = managers.assets:_get_asset_by_id(asset_id)
-			if asset.can_unlock then
-				managers.assets:unlock_asset(asset_id)
 			end
 		end
 	end

--- a/mods/REBuyAssets/mod.txt
+++ b/mods/REBuyAssets/mod.txt
@@ -3,7 +3,7 @@
 	"description":"REBuyAssets",
 	"author":"Dr_Newbie",
 	"contact":"http://modwork.shop/18798",
-	"version":"6",
+	"version":"7",
 	"image": "logo.png",
 	"color": "0 0 0",
 	"blt_version": 2,

--- a/mods/REBuyAssets/mod.txt
+++ b/mods/REBuyAssets/mod.txt
@@ -11,6 +11,7 @@
 	[
 		{"hook_id":"lib/managers/localizationmanager", "script_path":"lua/MenuFunction.lua"},
 		{"hook_id":"lib/managers/preplanningmanager", "script_path":"lua/preplanningmanager.lua"},
-		{"hook_id":"lib/managers/menu/missionbriefinggui", "script_path":"lua/missionbriefinggui.lua"}
+		{"hook_id":"lib/managers/menu/missionbriefinggui", "script_path":"lua/missionbriefinggui.lua"},
+		{"hook_id":"lib/managers/menu/missionbriefinggui", "script_path":"lua/autobuyallassets.lua"}
 	]
 }


### PR DESCRIPTION
- Lua Files
	- missionbriefinggui.lua
		- Added a block code to prevent the mod from working as a client/public lobbies.
		- Moved the auto buy feature to a new lua file named "autobuyallassets.lua". The auto buy feature will still work as both host and client.
- Ingame
	- Preplanning
		- Preplanning will no longer be loaded as a client/on public lobbies, the mod user will have to host a lobby for it to load properly.
		- Fixed an issue that would make the preplanning be autoloaded as a client/on public lobbies, making the favors have a negative value and preventing the mod user from removing or adding assets.